### PR TITLE
Correct installed links in case of openssl3, fix #11

### DIFF
--- a/install-openssl_3.sh
+++ b/install-openssl_3.sh
@@ -62,8 +62,8 @@ make
 
 mkdir -p %{buildroot}%{_bindir}
 mkdir -p %{buildroot}%{_libdir}
-ln -sf %{openssldir}/lib/libssl.so.1.1 %{buildroot}%{_libdir}
-ln -sf %{openssldir}/lib/libcrypto.so.1.1 %{buildroot}%{_libdir}
+ln -sf %{openssldir}/lib64/libssl.so.3 %{buildroot}%{_libdir}
+ln -sf %{openssldir}/lib64/libcrypto.so.3 %{buildroot}%{_libdir}
 ln -sf %{openssldir}/bin/openssl %{buildroot}%{_bindir}
 
 %clean
@@ -73,8 +73,8 @@ ln -sf %{openssldir}/bin/openssl %{buildroot}%{_bindir}
 %{openssldir}
 %defattr(-,root,root)
 /usr/bin/openssl
-/usr/lib64/libcrypto.so.1.1
-/usr/lib64/libssl.so.1.1
+/usr/lib64/libcrypto.so.3
+/usr/lib64/libssl.so.3
 
 %files devel
 %{openssldir}/include/*

--- a/openssl3.spec
+++ b/openssl3.spec
@@ -38,8 +38,8 @@ make
 
 mkdir -p %{buildroot}%{_bindir}
 mkdir -p %{buildroot}%{_libdir}
-ln -sf %{openssldir}/lib/libssl.so.1.1 %{buildroot}%{_libdir}
-ln -sf %{openssldir}/lib/libcrypto.so.1.1 %{buildroot}%{_libdir}
+ln -sf %{openssldir}/lib64/libssl.so.3 %{buildroot}%{_libdir}
+ln -sf %{openssldir}/lib64/libcrypto.so.3 %{buildroot}%{_libdir}
 ln -sf %{openssldir}/bin/openssl %{buildroot}%{_bindir}
 
 %clean
@@ -49,8 +49,8 @@ ln -sf %{openssldir}/bin/openssl %{buildroot}%{_bindir}
 %{openssldir}
 %defattr(-,root,root)
 /usr/bin/openssl
-/usr/lib64/libcrypto.so.1.1
-/usr/lib64/libssl.so.1.1
+/usr/lib64/libcrypto.so.3
+/usr/lib64/libssl.so.3
 
 %files devel
 %{openssldir}/include/*


### PR DESCRIPTION
Fix for #11 
Looks like links were wrongly copy-pasted from openssl1.1 spec. So openssl fails with following error:
  $ openssl version
  openssl: error while loading shared libraries: libssl.so.3: cannot open shared object file: No such file or directory
After fix openssl works correctly:
  $ openssl version
  OpenSSL 3.1.2 1 Aug 2023 (Library: OpenSSL 3.1.2 1 Aug 2023)